### PR TITLE
CLI for UDP(Do53) / DoT

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,28 @@ dot.aaaa
 
 ### CLI
 
-(TBD)
+- UDP(Do53)
+```sh
+$ ddig --udp --nameserver 8.8.8.8 dns.google
+dns.google	A	8.8.8.8
+dns.google	A	8.8.4.4
+dns.google	AAAA	2001:4860:4860::8844
+dns.google	AAAA	2001:4860:4860::8888
+
+# SERVER: 8.8.8.8
+```
+
+- DoT
+```sh
+$ ddig --dot --nameserver 8.8.8.8 dns.google
+dns.google	A	8.8.4.4
+dns.google	A	8.8.8.8
+dns.google	AAAA	2001:4860:4860::8844
+dns.google	AAAA	2001:4860:4860::8888
+
+# SERVER(Address): 8.8.8.8
+# PORT: 853
+```
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,28 @@ ddig[:ddr]
 ]
 ```
 
+- Do53
+```ruby
+do53 = Ddig::Resolver::Do53.new(hostname: 'dns.google', nameservers: '8.8.8.8').lookup
+=> #<Ddig::Resolver::Do53:0x0000000121717b78 @a=["8.8.8.8", "8.8.4.4"], @aaaa=["2001:4860:4860::8844", "2001:4860:4860::8888"], @hostname="dns.google", @ip=nil, @nameserver=#<Ddig::Nameserver:0x00000001211fb108 @nameservers="8.8.8.8", @servers=["8.8.8.8"]>, @nameservers=["8.8.8.8"]>
+
+do53.a
+=> ["8.8.4.4", "8.8.8.8"]
+do53.aaaa
+=> ["2001:4860:4860::8844", "2001:4860:4860::8888"]
+```
+
+- DoT
+```ruby
+dot = Ddig::Resolver::Dot.new(hostname: 'dns.google', server: '8.8.8.8').lookup
+=> #<Ddig::Resolver::Dot:0x000000012145da90 @a=["8.8.8.8", "8.8.4.4"], @aaaa=["2001:4860:4860::8844", "2001:4860:4860::8888"], @hostname="dns.google", @open_timeout=3, @port=853, @server="8.8.8.8", @server_name=nil>
+
+dot.a
+=> ["8.8.4.4", "8.8.8.8"]
+dot.aaaa
+=> ["2001:4860:4860::8844", "2001:4860:4860::8888"]
+```
+
 ### CLI
 
 (TBD)

--- a/lib/ddig/cli.rb
+++ b/lib/ddig/cli.rb
@@ -7,6 +7,7 @@ module Ddig
     def initialize(args)
       @args = args
       @options = {
+        type: 'all',
         format: 'text',
       }
 
@@ -22,7 +23,11 @@ module Ddig
       @option_parser = OptionParser.new do |opts|
         opts.banner = "Usage: ddig [options] hostname"
 
-        opts.on("--nameserver=ipaddress", "nameserver ip address") { |v| @options[:nameserver] = v }
+        opts.on("-t", "--type={all|do53|dot}", "resolve type (default: all)") { |v| @options[:type] = v }
+        opts.on("--udp", "use resolve type of udp(do53)") { |v| @options[:type] = 'do53' }
+        opts.on("--dot", "use resolve type of dot") { |v| @options[:type] = 'dot' }
+        opts.on("--nameserver=ipaddress", "nameserver") { |v| @options[:nameserver] = v }
+        opts.on("-p", "--port=port", "port") { |v| @options[:port] = v }
         opts.on("--format={text|json}", "output format (default: text)") { |v| @options[:format] = v }
 
         opts.separator ""
@@ -38,18 +43,59 @@ module Ddig
     end
 
     def exec
-      @ddig = Ddig.lookup(@hostname, nameservers: [@options[:nameserver]])
+      case @options[:type]
+      when "all"
+        resolve_all
+      when "do53"
+        resolve_do53
+      when "dot"
+        resolve_dot
+      end
+    end
+
+    def resolve_all
+      @ddig = Ddig.lookup(@hostname, nameservers: @options[:nameserver])
 
       if @options[:format] == 'json'
         # TODO: to_json
         puts @ddig
       else
-        print_result
+        puts @ddig
       end
     end
 
-    def print_result
-      puts @ddig
+    def resolve_do53
+      do53 = Ddig::Resolver::Do53.new(hostname: @hostname, nameservers: @options[:nameserver]).lookup
+
+      do53.a.each do |address|
+        rr_type = 'A'
+        puts "#{@hostname}\t#{rr_type}\t#{address}"
+      end
+      do53.aaaa.each do |address|
+        rr_type = 'AAAA'
+        puts "#{@hostname}\t#{rr_type}\t#{address}"
+      end
+
+      puts
+      puts "# SERVER: #{do53.nameservers.join(', ')}"
+    end
+
+    def resolve_dot
+      dot = Ddig::Resolver::Dot.new(hostname: @hostname, server: @options[:nameserver], port: @options[:port]).lookup
+
+      dot.a.each do |address|
+        rr_type = 'A'
+        puts "#{@hostname}\t#{rr_type}\t#{address}"
+      end
+      dot.aaaa.each do |address|
+        rr_type = 'AAAA'
+        puts "#{@hostname}\t#{rr_type}\t#{address}"
+      end
+
+      puts
+      puts "# SERVER(Address): #{dot.server}"
+      #puts "# SERVER(Hostname): #{dot.server_name}"
+      puts "# PORT: #{dot.port}"
     end
   end
 end

--- a/lib/ddig/resolver/dot.rb
+++ b/lib/ddig/resolver/dot.rb
@@ -12,7 +12,7 @@ module Ddig
         @hostname = hostname
         @server = server
         @server_name = server_name
-        @port = port
+        @port = port || 853
 
         @open_timeout = 3
       end

--- a/spec/ddig/resolver/dot_spec.rb
+++ b/spec/ddig/resolver/dot_spec.rb
@@ -65,4 +65,24 @@ RSpec.describe Ddig::Resolver::Dot do
       }.to raise_error(OpenSSL::SSL::SSLError) # error: certificate verify failed (hostname mismatch)
     end
   end
+
+  context "set port attribute" do
+    it "return default port without port" do
+      @dot = Ddig::Resolver::Dot.new(hostname: 'dns.google', server: 'dns.google')
+
+      expect(@dot.port).to eq 853
+    end
+
+    it "return default port wit nil value of port" do
+      @dot = Ddig::Resolver::Dot.new(hostname: 'dns.google', server: 'dns.google', port: nil)
+
+      expect(@dot.port).to eq 853
+    end
+
+    it "return port with port value" do
+      @dot = Ddig::Resolver::Dot.new(hostname: 'dns.google', server: 'dns.google', port: 8853)
+
+      expect(@dot.port).to eq 8853
+    end
+  end
 end


### PR DESCRIPTION
### Summary
Update CLI for UDP(Do53) / DoT

### Change Set
- Added cli option of resolve type: `--type` / `--udp` / `--dot`
- Added cli option\: `--port` (only dot)

### Usage
- UDP(Do53)
```sh
$ ddig --udp --nameserver 8.8.8.8 dns.google
dns.google	A	8.8.8.8
dns.google	A	8.8.4.4
dns.google	AAAA	2001:4860:4860::8844
dns.google	AAAA	2001:4860:4860::8888

# SERVER: 8.8.8.8
```

- DoT
```sh
$ ddig --dot --nameserver 8.8.8.8 dns.google
dns.google	A	8.8.4.4
dns.google	A	8.8.8.8
dns.google	AAAA	2001:4860:4860::8844
dns.google	AAAA	2001:4860:4860::8888

# SERVER(Address): 8.8.8.8
# PORT: 853
```