### PR TITLE
Add DoH client (HTTP/1.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ dns.google	AAAA	2001:4860:4860::8844
 
 - DoH (HTTP/1.1)
 ```sh
-$ ddig --doh-http1.1 --nameserver dns.google --doh-path /dns-query{?dns} dns.google
+$ ddig --doh-h1 --nameserver dns.google --doh-path /dns-query{?dns} dns.google
 dns.google	A	8.8.8.8
 dns.google	A	8.8.4.4
 dns.google	AAAA	2001:4860:4860::8888

--- a/README.md
+++ b/README.md
@@ -108,6 +108,17 @@ dot.aaaa
 => ["2001:4860:4860::8844", "2001:4860:4860::8888"]
 ```
 
+- DoH (HTTP/1.1)
+```ruby
+doh = Ddig::Resolver::DohH1.new(hostname: 'dns.google', server: 'dns.google', dohpath: '/dns-query{?dns}').lookup
+=> #<Ddig::Resolver::DohH1:0x00000001023ed020 @a=["8.8.4.4", "8.8.8.8"], @aaaa=["2001:4860:4860::8888", "2001:4860:4860::8844"], @address=nil, @dohpath="/dns-query{?dns}", @hostname="dns.google", @open_timeout=10, @port=443, @server="dns.google">
+
+doh.a
+=> ["8.8.4.4", "8.8.8.8"]
+doh.aaaa
+=> ["2001:4860:4860::8844", "2001:4860:4860::8888"]
+```
+
 ### CLI
 
 - UDP(Do53)
@@ -124,13 +135,26 @@ dns.google	AAAA	2001:4860:4860::8888
 - DoT
 ```sh
 $ ddig --dot --nameserver 8.8.8.8 dns.google
-dns.google	A	8.8.4.4
 dns.google	A	8.8.8.8
-dns.google	AAAA	2001:4860:4860::8844
+dns.google	A	8.8.4.4
 dns.google	AAAA	2001:4860:4860::8888
+dns.google	AAAA	2001:4860:4860::8844
 
 # SERVER(Address): 8.8.8.8
 # PORT: 853
+```
+
+- DoH (HTTP/1.1)
+```sh
+$ ddig --doh-http1.1 --nameserver dns.google --doh-path /dns-query{?dns} dns.google
+dns.google	A	8.8.8.8
+dns.google	A	8.8.4.4
+dns.google	AAAA	2001:4860:4860::8888
+dns.google	AAAA	2001:4860:4860::8844
+
+# SERVER(Hostname): dns.google
+# SERVER(Path): /dns-query{?dns}
+# PORT: 443
 ```
 
 ## Development

--- a/ddig.gemspec
+++ b/ddig.gemspec
@@ -31,4 +31,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "resolv", "~> 0.3.0"
+  spec.add_dependency "base64" if RUBY_VERSION >= '3.3'
 end

--- a/lib/ddig.rb
+++ b/lib/ddig.rb
@@ -4,6 +4,7 @@ require_relative "ddig/version"
 require_relative "ddig/nameserver"
 require_relative "ddig/resolver/do53"
 require_relative "ddig/resolver/dot"
+require_relative "ddig/resolver/doh_h1"
 require_relative "ddig/ddr"
 
 module Ddig

--- a/lib/ddig/cli.rb
+++ b/lib/ddig/cli.rb
@@ -26,7 +26,7 @@ module Ddig
         opts.on("-t", "--type={all|do53|dot}", "resolve type (default: all)") { |v| @options[:type] = v }
         opts.on("--udp", "use resolve type of udp(do53)") { |v| @options[:type] = 'do53' }
         opts.on("--dot", "use resolve type of dot") { |v| @options[:type] = 'dot' }
-        opts.on("--doh-http1.1", "use resolve type of doh (http/1.1)") { |v| @options[:type] = 'doh_h1' }
+        opts.on("--doh-h1", "use resolve type of doh (http/1.1)") { |v| @options[:type] = 'doh_h1' }
         opts.on("--doh-path=doh-path", "doh service path") { |v| @options[:doh_path] = v }
         opts.on("-@", "--nameserver=ipaddress|doh-hostname", "nameserver") { |v| @options[:nameserver] = v }
         opts.on("-p", "--port=port", "port") { |v| @options[:port] = v }

--- a/lib/ddig/resolver/dns_message.rb
+++ b/lib/ddig/resolver/dns_message.rb
@@ -1,0 +1,40 @@
+require 'resolv'
+
+module Ddig
+  module Resolver
+    class DnsMessage
+      def self.encode(hostname, typeclass)
+        if hostname.nil?
+          return nil
+        end
+        if typeclass.nil?
+          return nil
+        end
+
+        message = Resolv::DNS::Message.new
+        message.rd = 1 # recursive query
+        message.add_question(hostname, typeclass)
+
+        message.encode
+      end
+
+      def self.decode(payload)
+        if payload.nil?
+          return nil
+        end
+
+        Resolv::DNS::Message.decode(payload)
+      end
+
+      def self.getresources(payload)
+        if payload.nil?
+          return []
+        end
+
+        response = self.decode(payload)
+
+        return response.answer.map { |name, ttl, resource| resource }
+      end
+    end
+  end
+end

--- a/lib/ddig/resolver/doh_h1.rb
+++ b/lib/ddig/resolver/doh_h1.rb
@@ -1,0 +1,76 @@
+require 'net/http'
+require 'resolv'
+require 'base64'
+
+module Ddig
+  module Resolver
+    # DNS over HTTPS (HTTP/1.1)
+    class DohH1
+      attr_reader :hostname, :server, :address, :dohpath, :port
+      attr_reader :a, :aaaa
+
+      def initialize(hostname:, server:, address: nil, dohpath:, port: 443)
+        @hostname = hostname
+        @server = server
+        @address = address
+        @dohpath = dohpath
+        @port = port || 443
+
+        @open_timeout = 10
+      end
+
+      def lookup
+        if @server.nil?
+          return nil
+        end
+
+        @a = get_resources(@hostname, Resolv::DNS::Resource::IN::A).map { |resource| resource.address.to_s if resource.is_a?(Resolv::DNS::Resource::IN::A) }.compact
+
+        @aaaa = get_resources(@hostname, Resolv::DNS::Resource::IN::AAAA).map { |resource| resource.address.to_s if resource.is_a?(Resolv::DNS::Resource::IN::AAAA) }.compact
+
+        self
+      end
+
+      def get_resources(hostname, typeclass)
+        # send query
+        message = dns_message(hostname, typeclass)
+        request = [message.encode.length].pack('n') + message.encode
+
+        path_with_query = @dohpath.gsub('{?dns}', '?dns=' + Base64.urlsafe_encode64(message.encode, padding: false))
+
+        http_response = Net::HTTP.start(@server, @port, use_ssl: true) do |http|
+          unless @address.nil?
+            http.ipaddr = @address
+          end
+          header = {}
+          header['Accept'] = 'application/dns-message'
+          #http.open_timeout = @open_timeout
+
+          http.get(path_with_query, header)
+        end
+
+        # recive answer
+        response = Resolv::DNS::Message.decode(http_response.body)
+
+        resources = response.answer.map { |name, ttl, resource| resource }
+
+        resources
+      end
+
+      def dns_message(hostname, typeclass)
+        if hostname.nil?
+          return nil
+        end
+        if typeclass.nil?
+          return nil
+        end
+
+        message = Resolv::DNS::Message.new
+        message.rd = 1 # recursive query
+        message.add_question(hostname, typeclass)
+
+        message
+      end
+    end
+  end
+end

--- a/lib/ddig/resolver/doh_h1.rb
+++ b/lib/ddig/resolver/doh_h1.rb
@@ -38,10 +38,7 @@ module Ddig
 
         path_with_query = @dohpath.gsub('{?dns}', '?dns=' + Base64.urlsafe_encode64(message.encode, padding: false))
 
-        http_response = Net::HTTP.start(@server, @port, use_ssl: true) do |http|
-          unless @address.nil?
-            http.ipaddr = @address
-          end
+        http_response = Net::HTTP.start(@server, @port, use_ssl: true, ipaddr: @address) do |http|
           header = {}
           header['Accept'] = 'application/dns-message'
           #http.open_timeout = @open_timeout

--- a/lib/ddig/resolver/doh_h1.rb
+++ b/lib/ddig/resolver/doh_h1.rb
@@ -47,10 +47,14 @@ module Ddig
           http.get(path_with_query, header)
         end
 
-        # recive answer
-        resources = DnsMessage.getresources(http_response.body)
-
-        resources
+        case http_response
+        when Net::HTTPSuccess
+          # recive answer
+          return DnsMessage.getresources(http_response.body)
+        else
+          http_response.value
+          return []
+        end
       end
     end
   end

--- a/spec/ddig/resolver/doh_h1_spec.rb
+++ b/spec/ddig/resolver/doh_h1_spec.rb
@@ -62,7 +62,9 @@ RSpec.describe Ddig::Resolver::DohH1 do
     it "raise Error" do
       expect {
         @doh.lookup
-      }.to raise_error(OpenSSL::SSL::SSLError) # error: certificate verify failed (hostname mismatch)
+      }.to raise_error(StandardError)
+      # ruby2.7+: OpenSSL::SSL::SSLError: certificate verify failed (hostname mismatch)
+      # ruby2.6: Net::HTTPServerException: 404 "Not Found"
     end
   end
 

--- a/spec/ddig/resolver/doh_h1_spec.rb
+++ b/spec/ddig/resolver/doh_h1_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+RSpec.describe Ddig::Resolver::DohH1 do
+  context "#lookup" do
+    before(:each) do
+      @doh = Ddig::Resolver::DohH1.new(hostname: 'dns.google', server: 'dns.google', dohpath: '/dns-query{?dns}')
+      @doh.lookup
+    end
+
+    it "a/aaaa return values" do
+      # a
+      expect(@doh.a).to include "8.8.8.8"
+      expect(@doh.a).to include "8.8.4.4"
+
+      # aaaa
+      expect(@doh.aaaa).to include "2001:4860:4860::8844"
+      expect(@doh.aaaa).to include "2001:4860:4860::8888"
+    end
+  end
+
+  context "#lookup: with server (ipv4) / address" do
+    before(:each) do
+      @doh = Ddig::Resolver::DohH1.new(hostname: 'dns.google', server: 'dns.google', address: '8.8.8.8', dohpath: '/dns-query{?dns}')
+      @doh.lookup
+    end
+
+    it "a/aaaa return values" do
+      # a
+      expect(@doh.a).to include "8.8.8.8"
+      expect(@doh.a).to include "8.8.4.4"
+
+      # aaaa
+      expect(@doh.aaaa).to include "2001:4860:4860::8844"
+      expect(@doh.aaaa).to include "2001:4860:4860::8888"
+    end
+  end
+
+  context "#lookup: with server (ipv6) / address" do
+    before(:each) do
+      skip 'IPv6 is not available' unless enable_ipv6?
+
+      @doh = Ddig::Resolver::DohH1.new(hostname: 'dns.google', server: 'dns.google', address: '2001:4860:4860::8888', dohpath: '/dns-query{?dns}')
+      @doh.lookup
+    end
+
+    it "a/aaaa return values" do
+      # a
+      expect(@doh.a).to include "8.8.8.8"
+      expect(@doh.a).to include "8.8.4.4"
+
+      # aaaa
+      expect(@doh.aaaa).to include "2001:4860:4860::8844"
+      expect(@doh.aaaa).to include "2001:4860:4860::8888"
+    end
+  end
+
+  context "#lookup: with invalid address" do
+    before(:each) do
+      @doh = Ddig::Resolver::DohH1.new(hostname: 'dns.google', server: 'example.com', address: '8.8.8.8', dohpath: '/dns-query{?dns}')
+    end
+
+    it "raise Error" do
+      expect {
+        @doh.lookup
+      }.to raise_error(OpenSSL::SSL::SSLError) # error: certificate verify failed (hostname mismatch)
+    end
+  end
+
+  context "set port attribute" do
+    it "return default port without port" do
+      @doh = Ddig::Resolver::DohH1.new(hostname: 'dns.google', server: 'dns.google', dohpath: '/dns-query{?dns}')
+
+      expect(@doh.port).to eq 443
+    end
+
+    it "return default port wit nil value of port" do
+      @doh = Ddig::Resolver::DohH1.new(hostname: 'dns.google', server: 'dns.google', dohpath: '/dns-query{?dns}', port: nil)
+
+      expect(@doh.port).to eq 443
+    end
+
+    it "return port with port value" do
+      @doh = Ddig::Resolver::DohH1.new(hostname: 'dns.google', server: 'dns.google', dohpath: '/dns-query{?dns}', port: 8443)
+
+      expect(@doh.port).to eq 8443
+    end
+  end
+end


### PR DESCRIPTION
### Summary
Add DoH client (HTTP/1.1) via Net::HTTP

### Change Set
- Added resolver of doh client (http/1.1)
- Added cli option of resolve type: `--doh-h1`

### Usage
- Ruby
```ruby
doh = Ddig::Resolver::DohH1.new(hostname: 'dns.google', server: 'dns.google', dohpath: '/dns-query{?dns}').lookup
=> #<Ddig::Resolver::DohH1:0x00000001023ed020 @a=["8.8.4.4", "8.8.8.8"], @aaaa=["2001:4860:4860::8888", "2001:4860:4860::8844"], @address=nil, @dohpath="/dns-query{?dns}", @hostname="dns.google", @open_timeout=10, @port=443, @server="dns.google">

doh.a
=> ["8.8.4.4", "8.8.8.8"]
doh.aaaa
=> ["2001:4860:4860::8844", "2001:4860:4860::8888"]
```

- CLI
```sh
$ ddig --doh-h1 --nameserver dns.google --doh-path /dns-query{?dns} dns.google
dns.google	A	8.8.8.8
dns.google	A	8.8.4.4
dns.google	AAAA	2001:4860:4860::8888
dns.google	AAAA	2001:4860:4860::8844

# SERVER(Hostname): dns.google
# SERVER(Path): /dns-query{?dns}
# PORT: 443
```
