### PR TITLE
Fix default port 443 with doh http/1.1

### DIFF
--- a/lib/ddig/ddr/designated_resolver.rb
+++ b/lib/ddig/ddr/designated_resolver.rb
@@ -77,9 +77,7 @@ module Ddig
       # ref: https://www.rfc-editor.org/rfc/rfc9461.html#section-4.2
       def set_default_port
         case @protocol
-        when 'http/1.1'
-          @port = 80
-        when 'h2', 'h3'
+        when 'http/1.1', 'h2', 'h3'
           @port = 443
         when 'dot', 'doq'
           @port = 853

--- a/spec/ddig/ddr/designated_resolver_spec.rb
+++ b/spec/ddig/ddr/designated_resolver_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Ddig::Ddr::DesignatedResolver do
       it "return default port with protocol: http/1.1" do
         @designated_resolver = Ddig::Ddr::DesignatedResolver.new(unencrypted_resolver: '8.8.8.8', target: 'dns.google', protocol: 'http/1.1', port: nil, dohpath: nil, address: '8.8.4.4', ip: :ipv4)
 
-        expect(@designated_resolver.port).to eq 80
+        expect(@designated_resolver.port).to eq 443
       end
 
       it "return default port with protocol: h2" do


### PR DESCRIPTION
### Summary
Fix default port 443 with doh http/1.1

### Change Set
-  DesignatedResolver: default port with doh http/1.1