### PR TITLE
Fix resolv dependency to allow versions 0.4.0 and higher

### DIFF
--- a/ddig.gemspec
+++ b/ddig.gemspec
@@ -30,6 +30,6 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "resolv", "~> 0.3.0"
+  spec.add_dependency "resolv", ">= 0.3.0"
   spec.add_dependency "base64"
 end


### PR DESCRIPTION
This Pull Request updates the version constraint for the `resolv` gem in the `ddig` dependencies.

It fixes the constraint to allow using version `0.4.0` or higher of `resolv`.