### PR TITLE
Require MFA for gem releases

### DIFF
--- a/ddig.gemspec
+++ b/ddig.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |spec|
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/taketo1113/ddig"
   spec.metadata["changelog_uri"] = "https://github.com/taketo1113/ddig/releases"
+  spec.metadata["rubygems_mfa_required"] = "true"
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.


### PR DESCRIPTION
### Summary
This Pull Request adds to require MFA for gem releases.

### Related Links
- MFA requirement opt-in - RubyGems Guides
  - https://guides.rubygems.org/mfa-requirement-opt-in/
