### PR TITLE
Add query response time (a_response_time/aaaa_response_time)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ If bundler is not being used to manage dependencies, install the gem by executin
 ddig = Ddig.lookup('dns.google', nameservers: ['8.8.8.8', '2001:4860:4860::8888'])
 
 ddig[:do53][:ipv4]
-=> #<Ddig::Resolver::Do53:0x00000001207aaeb0 @a=["8.8.4.4", "8.8.8.8"], @aaaa=["2001:4860:4860::8844", "2001:4860:4860::8888"], @hostname="dns.google", @ip=:ipv4, @nameservers=["8.8.8.8"]>
+=> #<Ddig::Resolver::Do53:0x00000001207aaeb0 @a=["8.8.4.4", "8.8.8.8"], @a_response_time=18, @aaaa=["2001:4860:4860::8844", "2001:4860:4860::8888"], @aaaa_response_time=16, @hostname="dns.google", @ip=:ipv4, @nameservers=["8.8.8.8"]>
 ddig[:do53][:ipv6]
-=> #<Ddig::Resolver::Do53:0x000000012073d2c0 @a=["8.8.4.4", "8.8.8.8"], @aaaa=["2001:4860:4860::8844", "2001:4860:4860::8888"], @hostname="dns.google", @ip=:ipv4, @nameservers=["2001:4860:4860::8888"]>
+=> #<Ddig::Resolver::Do53:0x000000012073d2c0 @a=["8.8.4.4", "8.8.8.8"], @a_response_time=18, @aaaa=["2001:4860:4860::8844", "2001:4860:4860::8888"], @aaaa_response_time=16, @hostname="dns.google", @ip=:ipv4, @nameservers=["2001:4860:4860::8888"]>
 
 ddig[:ddr]
 => [#<Ddig::Ddr::DesignatedResolver:0x0000000120735480
@@ -90,7 +90,7 @@ ddig[:ddr]
 - Do53
 ```ruby
 do53 = Ddig::Resolver::Do53.new(hostname: 'dns.google', nameservers: '8.8.8.8').lookup
-=> #<Ddig::Resolver::Do53:0x0000000121717b78 @a=["8.8.8.8", "8.8.4.4"], @aaaa=["2001:4860:4860::8844", "2001:4860:4860::8888"], @hostname="dns.google", @ip=nil, @nameserver=#<Ddig::Nameserver:0x00000001211fb108 @nameservers="8.8.8.8", @servers=["8.8.8.8"]>, @nameservers=["8.8.8.8"]>
+=> #<Ddig::Resolver::Do53:0x0000000121717b78 @a=["8.8.8.8", "8.8.4.4"], @a_response_time=18, @aaaa=["2001:4860:4860::8844", "2001:4860:4860::8888"], @aaaa_response_time=16, @hostname="dns.google", @ip=nil, @nameserver=#<Ddig::Nameserver:0x00000001211fb108 @nameservers="8.8.8.8", @servers=["8.8.8.8"]>, @nameservers=["8.8.8.8"]>
 
 do53.a
 => ["8.8.4.4", "8.8.8.8"]
@@ -101,7 +101,7 @@ do53.aaaa
 - DoT
 ```ruby
 dot = Ddig::Resolver::Dot.new(hostname: 'dns.google', server: '8.8.8.8').lookup
-=> #<Ddig::Resolver::Dot:0x000000012145da90 @a=["8.8.8.8", "8.8.4.4"], @aaaa=["2001:4860:4860::8844", "2001:4860:4860::8888"], @hostname="dns.google", @open_timeout=3, @port=853, @server="8.8.8.8", @server_name=nil>
+=> #<Ddig::Resolver::Dot:0x000000012145da90 @a=["8.8.8.8", "8.8.4.4"], @a_response_time=108, @aaaa=["2001:4860:4860::8844", "2001:4860:4860::8888"], @aaaa_response_time=122, @hostname="dns.google", @open_timeout=3, @port=853, @server="8.8.8.8", @server_name=nil>
 
 dot.a
 => ["8.8.4.4", "8.8.8.8"]
@@ -112,7 +112,7 @@ dot.aaaa
 - DoH (HTTP/1.1)
 ```ruby
 doh = Ddig::Resolver::DohH1.new(hostname: 'dns.google', server: 'dns.google', dohpath: '/dns-query{?dns}').lookup
-=> #<Ddig::Resolver::DohH1:0x00000001023ed020 @a=["8.8.4.4", "8.8.8.8"], @aaaa=["2001:4860:4860::8888", "2001:4860:4860::8844"], @address=nil, @dohpath="/dns-query{?dns}", @hostname="dns.google", @open_timeout=10, @port=443, @server="dns.google">
+=> #<Ddig::Resolver::DohH1:0x00000001023ed020 @a=["8.8.4.4", "8.8.8.8"], @a_response_time=62, @aaaa=["2001:4860:4860::8888", "2001:4860:4860::8844"], @aaaa_response_time=77, @address=nil, @dohpath="/dns-query{?dns}", @hostname="dns.google", @open_timeout=10, @port=443, @server="dns.google">
 
 doh.a
 => ["8.8.4.4", "8.8.8.8"]
@@ -151,6 +151,8 @@ dns.google	A	8.8.8.8
 dns.google	AAAA	2001:4860:4860::8844
 dns.google	AAAA	2001:4860:4860::8888
 
+# Query time (A):    15 msec
+# Query time (AAAA): 15 msec
 # SERVER: 8.8.8.8
 
 # DDR
@@ -160,6 +162,8 @@ dns.google	A	8.8.8.8
 dns.google	AAAA	2001:4860:4860::8844
 dns.google	AAAA	2001:4860:4860::8888
 
+# Query time (A):    114 msec
+# Query time (AAAA): 187 msec
 # SERVER(Address): 8.8.4.4
 # PORT: 853
 
@@ -174,6 +178,8 @@ dns.google	A	8.8.4.4
 dns.google	AAAA	2001:4860:4860::8844
 dns.google	AAAA	2001:4860:4860::8888
 
+# Query time (A):    89 msec
+# Query time (AAAA): 105 msec
 # SERVER(Hostname): 2001:4860:4860::8888
 # SERVER(Path): /dns-query{?dns}
 # PORT: 443
@@ -188,6 +194,8 @@ dns.google	A	8.8.4.4
 dns.google	AAAA	2001:4860:4860::8844
 dns.google	AAAA	2001:4860:4860::8888
 
+# Query time (A):    20 msec
+# Query time (AAAA): 16 msec
 # SERVER: 8.8.8.8
 ```
 
@@ -199,6 +207,8 @@ dns.google	A	8.8.4.4
 dns.google	AAAA	2001:4860:4860::8888
 dns.google	AAAA	2001:4860:4860::8844
 
+# Query time (A):    90 msec
+# Query time (AAAA): 167 msec
 # SERVER(Address): 8.8.8.8
 # PORT: 853
 ```
@@ -211,6 +221,8 @@ dns.google	A	8.8.4.4
 dns.google	AAAA	2001:4860:4860::8888
 dns.google	AAAA	2001:4860:4860::8844
 
+# Query time (A):    69 msec
+# Query time (AAAA): 70 msec
 # SERVER(Hostname): dns.google
 # SERVER(Path): /dns-query{?dns}
 # PORT: 443

--- a/lib/ddig/resolver/do53.rb
+++ b/lib/ddig/resolver/do53.rb
@@ -7,6 +7,7 @@ module Ddig
     class Do53
       attr_reader :hostname, :nameservers, :ip
       attr_reader :a, :aaaa
+      attr_reader :a_response_time, :aaaa_response_time
 
       def initialize(hostname:, nameservers: nil, ip: nil)
         @hostname = hostname
@@ -21,15 +22,19 @@ module Ddig
           return nil
         end
 
+        a_start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
         @a = Resolv::DNS.open(nameserver: @nameservers) do |dns|
           ress = dns.getresources(@hostname, Resolv::DNS::Resource::IN::A)
           ress.map { |resource| resource.address.to_s }
         end
+        @a_response_time = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - a_start) * 1000).round
 
+        aaaa_start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
         @aaaa = Resolv::DNS.open(nameserver: @nameservers) do |dns|
           ress = dns.getresources(@hostname, Resolv::DNS::Resource::IN::AAAA)
           ress.map { |resource| resource.address.to_s }
         end
+        @aaaa_response_time = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - aaaa_start) * 1000).round
 
         self
       end
@@ -41,6 +46,8 @@ module Ddig
           hostname: @hostname,
           nameservers: @nameservers,
           ip: @ip,
+          a_response_time: @a_response_time,
+          aaaa_response_time: @aaaa_response_time,
         }
       end
 
@@ -59,6 +66,12 @@ module Ddig
         end
 
         puts
+        unless @a_response_time.nil?
+          puts "# Query time (A):    #{@a_response_time} msec"
+        end
+        unless @aaaa_response_time.nil?
+          puts "# Query time (AAAA): #{@aaaa_response_time} msec"
+        end
         puts "# SERVER: #{@nameservers.join(', ')}"
       end
 

--- a/lib/ddig/resolver/doh_h1.rb
+++ b/lib/ddig/resolver/doh_h1.rb
@@ -11,6 +11,7 @@ module Ddig
     class DohH1
       attr_reader :hostname, :server, :address, :dohpath, :port
       attr_reader :a, :aaaa
+      attr_reader :a_response_time, :aaaa_response_time
 
       def initialize(hostname:, server:, address: nil, dohpath: '/dns-query{?dns}', port: 443)
         @hostname = hostname
@@ -27,9 +28,13 @@ module Ddig
           return nil
         end
 
+        a_start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
         @a = get_resources(@hostname, Resolv::DNS::Resource::IN::A).map { |resource| resource.address.to_s if resource.is_a?(Resolv::DNS::Resource::IN::A) }.compact
+        @a_response_time = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - a_start) * 1000).round
 
+        aaaa_start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
         @aaaa = get_resources(@hostname, Resolv::DNS::Resource::IN::AAAA).map { |resource| resource.address.to_s if resource.is_a?(Resolv::DNS::Resource::IN::AAAA) }.compact
+        @aaaa_response_time = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - aaaa_start) * 1000).round
 
         self
       end
@@ -67,6 +72,8 @@ module Ddig
           address: @address,
           dohpath: @dohpath,
           port: @port,
+          a_response_time: @a_response_time,
+          aaaa_response_time: @aaaa_response_time,
         }
       end
 
@@ -85,6 +92,12 @@ module Ddig
         end
 
         puts
+        unless @a_response_time.nil?
+          puts "# Query time (A):    #{@a_response_time} msec"
+        end
+        unless @aaaa_response_time.nil?
+          puts "# Query time (AAAA): #{@aaaa_response_time} msec"
+        end
         puts "# SERVER(Hostname): #{@server}"
         puts "# SERVER(Path): #{@dohpath}"
         puts "# PORT: #{@port}"

--- a/lib/ddig/resolver/dot.rb
+++ b/lib/ddig/resolver/dot.rb
@@ -10,6 +10,7 @@ module Ddig
     class Dot
       attr_reader :hostname, :server, :server_name, :port
       attr_reader :a, :aaaa
+      attr_reader :a_response_time, :aaaa_response_time
 
       def initialize(hostname:, server:, server_name: nil, port: 853)
         @hostname = hostname
@@ -25,9 +26,13 @@ module Ddig
           return nil
         end
 
+        a_start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
         @a = get_resources(@hostname, Resolv::DNS::Resource::IN::A).map { |resource| resource.address.to_s if resource.is_a?(Resolv::DNS::Resource::IN::A) }.compact
+        @a_response_time = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - a_start) * 1000).round
 
+        aaaa_start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
         @aaaa = get_resources(@hostname, Resolv::DNS::Resource::IN::AAAA).map { |resource| resource.address.to_s if resource.is_a?(Resolv::DNS::Resource::IN::AAAA) }.compact
+        @aaaa_response_time = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - aaaa_start) * 1000).round
 
         self
       end
@@ -84,6 +89,8 @@ module Ddig
           server: @server,
           server_name: @server_name,
           port: @port,
+          a_response_time: @a_response_time,
+          aaaa_response_time: @aaaa_response_time,
         }
       end
 
@@ -102,6 +109,12 @@ module Ddig
         end
 
         puts
+        unless @a_response_time.nil?
+          puts "# Query time (A):    #{@a_response_time} msec"
+        end
+        unless @aaaa_response_time.nil?
+          puts "# Query time (AAAA): #{@aaaa_response_time} msec"
+        end
         puts "# SERVER(Address): #{@server}"
         #puts "# SERVER(Hostname): #{@server_name}"
         puts "# PORT: #{@port}"

--- a/spec/ddig/resolver/do53_spec.rb
+++ b/spec/ddig/resolver/do53_spec.rb
@@ -17,6 +17,11 @@ RSpec.describe Ddig::Resolver::Do53 do
       expect(@do53.aaaa).to include "2001:4860:4860::8888"
     end
 
+    it "a_response_time / aaaa_response_time return value" do
+      expect(@do53.a_response_time).not_to be_nil
+      expect(@do53.aaaa_response_time).not_to be_nil
+    end
+
     it "hostname set value" do
       expect(@do53.hostname).to eq 'dns.google'
     end
@@ -46,6 +51,11 @@ RSpec.describe Ddig::Resolver::Do53 do
       # aaaa
       expect(@do53.aaaa).to include "2001:4860:4860::8844"
       expect(@do53.aaaa).to include "2001:4860:4860::8888"
+    end
+
+    it "a_response_time / aaaa_response_time return value" do
+      expect(@do53.a_response_time).not_to be_nil
+      expect(@do53.aaaa_response_time).not_to be_nil
     end
 
     it "hostname set value" do
@@ -93,6 +103,11 @@ RSpec.describe Ddig::Resolver::Do53 do
       expect(@do53.aaaa).to include "2001:4860:4860::8888"
     end
 
+    it "a_response_time / aaaa_response_time return value" do
+      expect(@do53.a_response_time).not_to be_nil
+      expect(@do53.aaaa_response_time).not_to be_nil
+    end
+
     it "hostname set value" do
       expect(@do53.hostname).to eq 'dns.google'
     end
@@ -127,6 +142,11 @@ RSpec.describe Ddig::Resolver::Do53 do
       expect(@do53.aaaa).to include "2001:4860:4860::8888"
     end
 
+    it "a_response_time / aaaa_response_time return value" do
+      expect(@do53.a_response_time).not_to be_nil
+      expect(@do53.aaaa_response_time).not_to be_nil
+    end
+
     it "hostname set value" do
       expect(@do53.hostname).to eq 'dns.google'
     end
@@ -154,6 +174,11 @@ RSpec.describe Ddig::Resolver::Do53 do
       # aaaa
       expect(@do53.as_json[:aaaa]).to include "2001:4860:4860::8844"
       expect(@do53.as_json[:aaaa]).to include "2001:4860:4860::8888"
+    end
+
+    it "a_response_time / aaaa_response_time return value" do
+      expect(@do53.as_json[:a_response_time]).not_to be_nil
+      expect(@do53.as_json[:aaaa_response_time]).not_to be_nil
     end
 
     it "hostname set value" do
@@ -204,6 +229,11 @@ RSpec.describe Ddig::Resolver::Do53 do
       # aaaa
       expect { @do53.to_cli }.to output(/2001:4860:4860::8888/).to_stdout
       expect { @do53.to_cli }.to output(/2001:4860:4860::8844/).to_stdout
+    end
+
+    it "a_response_time / aaaa_response_time return value" do
+      expect { @do53.to_cli }.to output(/Query time \(A\)/).to_stdout
+      expect { @do53.to_cli }.to output(/Query time \(AAAA\)/).to_stdout
     end
   end
 end

--- a/spec/ddig/resolver/doh_h1_spec.rb
+++ b/spec/ddig/resolver/doh_h1_spec.rb
@@ -16,6 +16,11 @@ RSpec.describe Ddig::Resolver::DohH1 do
       expect(@doh.aaaa).to include "2001:4860:4860::8844"
       expect(@doh.aaaa).to include "2001:4860:4860::8888"
     end
+
+    it "a_response_time / aaaa_response_time return value" do
+      expect(@doh.a_response_time).not_to be_nil
+      expect(@doh.aaaa_response_time).not_to be_nil
+    end
   end
 
   context "#lookup: with server (ipv4) / address" do
@@ -32,6 +37,11 @@ RSpec.describe Ddig::Resolver::DohH1 do
       # aaaa
       expect(@doh.aaaa).to include "2001:4860:4860::8844"
       expect(@doh.aaaa).to include "2001:4860:4860::8888"
+    end
+
+    it "a_response_time / aaaa_response_time return value" do
+      expect(@doh.a_response_time).not_to be_nil
+      expect(@doh.aaaa_response_time).not_to be_nil
     end
   end
 
@@ -51,6 +61,11 @@ RSpec.describe Ddig::Resolver::DohH1 do
       # aaaa
       expect(@doh.aaaa).to include "2001:4860:4860::8844"
       expect(@doh.aaaa).to include "2001:4860:4860::8888"
+    end
+
+    it "a_response_time / aaaa_response_time return value" do
+      expect(@doh.a_response_time).not_to be_nil
+      expect(@doh.aaaa_response_time).not_to be_nil
     end
   end
 
@@ -102,6 +117,11 @@ RSpec.describe Ddig::Resolver::DohH1 do
       # aaaa
       expect(@doh.as_json[:aaaa]).to include "2001:4860:4860::8844"
       expect(@doh.as_json[:aaaa]).to include "2001:4860:4860::8888"
+    end
+
+    it "a_response_time / aaaa_response_time return value" do
+      expect(@doh.as_json[:a_response_time]).not_to be_nil
+      expect(@doh.as_json[:aaaa_response_time]).not_to be_nil
     end
 
     it "hostname set value" do
@@ -168,6 +188,11 @@ RSpec.describe Ddig::Resolver::DohH1 do
       # aaaa
       expect { @doh.to_cli }.to output(/2001:4860:4860::8888/).to_stdout
       expect { @doh.to_cli }.to output(/2001:4860:4860::8844/).to_stdout
+    end
+
+    it "a_response_time / aaaa_response_time return value" do
+      expect { @doh.to_cli }.to output(/Query time \(A\)/).to_stdout
+      expect { @doh.to_cli }.to output(/Query time \(AAAA\)/).to_stdout
     end
 
     it "hostname return values" do

--- a/spec/ddig/resolver/dot_spec.rb
+++ b/spec/ddig/resolver/dot_spec.rb
@@ -16,6 +16,11 @@ RSpec.describe Ddig::Resolver::Dot do
       expect(@dot.aaaa).to include "2001:4860:4860::8844"
       expect(@dot.aaaa).to include "2001:4860:4860::8888"
     end
+
+    it "a_response_time / aaaa_response_time return value" do
+      expect(@dot.a_response_time).not_to be_nil
+      expect(@dot.aaaa_response_time).not_to be_nil
+    end
   end
 
   context "#lookup: with server (ipv4) / server_name" do
@@ -32,6 +37,11 @@ RSpec.describe Ddig::Resolver::Dot do
       # aaaa
       expect(@dot.aaaa).to include "2001:4860:4860::8844"
       expect(@dot.aaaa).to include "2001:4860:4860::8888"
+    end
+
+    it "a_response_time / aaaa_response_time return value" do
+      expect(@dot.a_response_time).not_to be_nil
+      expect(@dot.aaaa_response_time).not_to be_nil
     end
   end
 
@@ -51,6 +61,11 @@ RSpec.describe Ddig::Resolver::Dot do
       # aaaa
       expect(@dot.aaaa).to include "2001:4860:4860::8844"
       expect(@dot.aaaa).to include "2001:4860:4860::8888"
+    end
+
+    it "a_response_time / aaaa_response_time return value" do
+      expect(@dot.a_response_time).not_to be_nil
+      expect(@dot.aaaa_response_time).not_to be_nil
     end
   end
 
@@ -100,6 +115,11 @@ RSpec.describe Ddig::Resolver::Dot do
       # aaaa
       expect(@dot.as_json[:aaaa]).to include "2001:4860:4860::8844"
       expect(@dot.as_json[:aaaa]).to include "2001:4860:4860::8888"
+    end
+
+    it "a_response_time / aaaa_response_time return value" do
+      expect(@dot.as_json[:a_response_time]).not_to be_nil
+      expect(@dot.as_json[:aaaa_response_time]).not_to be_nil
     end
 
     it "hostname set value" do
@@ -158,6 +178,11 @@ RSpec.describe Ddig::Resolver::Dot do
       # aaaa
       expect { @dot.to_cli }.to output(/2001:4860:4860::8888/).to_stdout
       expect { @dot.to_cli }.to output(/2001:4860:4860::8844/).to_stdout
+    end
+
+    it "a_response_time / aaaa_response_time return value" do
+      expect { @dot.to_cli }.to output(/Query time \(A\)/).to_stdout
+      expect { @dot.to_cli }.to output(/Query time \(AAAA\)/).to_stdout
     end
 
     it "server return values" do


### PR DESCRIPTION
### Summary
Add query response time (a_response_time/aaaa_response_time)

### Changes
Add attribute of query response time (a_response_time/aaaa_response_time) in `Ddig::Resolver::*`

```diff
Ddig::Resolver::Do53.new(hostname: 'dns.google', nameservers: '8.8.8.8').lookup
=> #<Ddig::Resolver::Do53:0x00000001252078c8
 @a=["8.8.8.8", "8.8.4.4"],
+ @a_response_time=23,
 @aaaa=["2001:4860:4860::8844", "2001:4860:4860::8888"],
+ @aaaa_response_time=16,
 @hostname="dns.google",
 @ip=nil,
 @nameserver=#<Ddig::Nameserver:0x00000001252077b0 @nameservers="8.8.8.8", @servers=["8.8.8.8"]>,
 @nameservers=["8.8.8.8"]>
```

Add query response time (Query time (A)/Query time (AAAA)) in CLI results.
```diff
$ bundle exec ddig --udp dns.google -@ 8.8.8.8
dns.google	A	8.8.4.4
dns.google	A	8.8.8.8
dns.google	AAAA	2001:4860:4860::8844
dns.google	AAAA	2001:4860:4860::8888

+# Query time (A):    30 msec
+# Query time (AAAA): 13 msec
# SERVER: 8.8.8.8
```


### Related Links
- Close #17