### PR TITLE
Fix JSON output ignored when using resolve type options in CLI

### DIFF
--- a/lib/ddig/cli.rb
+++ b/lib/ddig/cli.rb
@@ -121,13 +121,21 @@ module Ddig
         exit
       end
 
-      do53.to_cli
+      if @options[:format] == 'json'
+        puts do53.to_json
+      else
+        do53.to_cli
+      end
     end
 
     def resolve_dot
       dot = Ddig::Resolver::Dot.new(hostname: @hostname, server: @options[:nameserver], port: @options[:port]).lookup
 
-      dot.to_cli
+      if @options[:format] == 'json'
+        puts dot.to_json
+      else
+        dot.to_cli
+      end
     end
 
     def resolve_doh_h1
@@ -137,14 +145,22 @@ module Ddig
 
       doh = Ddig::Resolver::DohH1.new(hostname: @hostname, server: @options[:nameserver], dohpath: @options[:doh_path], port: @options[:port]).lookup
 
-      doh.to_cli
+      if @options[:format] == 'json'
+        puts dot.to_json
+      else
+        doh.to_cli
+      end
     end
 
     def resolve_ddr
       ip = Ddig::Ip.new(use_ipv4: @use_ipv4, use_ipv6: @use_ipv6)
       ddr = Ddig::Ddr.new(nameservers: @options[:nameserver], ip: ip.ip_type)
 
-      ddr.to_cli
+      if @options[:format] == 'json'
+        puts ddr.to_json
+      else
+        ddr.to_cli
+      end
     end
   end
 end


### PR DESCRIPTION
### Summary
This Pull Request fixes an issue where the output format is not correctly applied when using a specific resolve type together with JSON format.

### Steps to reproduce
Run the CLI with a resolve type other than `all` (e.g., `--udp`, `--dot`, `--doh-h1`) and specify `--format json`.

```sh
$ bundle exec ddig --udp --format json dns.google -@ 8.8.8.8
```

### Expected behavior

The result should be output in JSON format.

```sh
$ bundle exec ddig --udp --format json dns.google -@ 8.8.8.8
{"a":["8.8.4.4","8.8.8.8"],"aaaa":["2001:4860:4860::8844","2001:4860:4860::8888"],"hostname":"dns.google","nameservers":["8.8.8.8"],"ip":"ipv4","a_response_time":16,"aaaa_response_time":15}
```

### Actual behavior

The result is output in text format instead of JSON:
```sh
$ bundle exec ddig --udp --format json dns.google -@ 8.8.8.8
dns.google	A	8.8.8.8
dns.google	A	8.8.4.4
dns.google	AAAA	2001:4860:4860::8888
dns.google	AAAA	2001:4860:4860::8844

# Query time (A):    16 msec
# Query time (AAAA): 15 msec
# SERVER: 8.8.8.8
```

### Related Links
- #8
